### PR TITLE
Update de.py for pymatgen > v2021.3.4

### DIFF
--- a/aevo/de.py
+++ b/aevo/de.py
@@ -16,6 +16,7 @@ import json
 import hashlib
 import numpy as np
 import pymatgen as mg
+from pymatgen.core import Structure
 from pymatgen.io.vasp.inputs import Poscar
 
 __author__ = "Alexander Urban"
@@ -673,7 +674,7 @@ class Evolution(Serializable):
         print("   writing file: {}".format(filename))
 
         # pymatgen specific
-        s = mg.Structure(lattice=self.avec, species=types, coords=coords)
+        s = Structure(lattice=self.avec, species=types, coords=coords)
         p = Poscar(structure=s)
         p.write_file(filename)
 


### PR DESCRIPTION
With the v2021.3.4 update of pymatgen, the majority of basic functionalities have been moved to pymatgen.core. This means aevo is no longer comaptible with newer pymatgen version. By importing the Structure class from pymatgen.core, the issue should be fixed